### PR TITLE
GitHub has killed off the git:// protocol

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,10 +3,10 @@
 	url = https://github.com/arduino/OpenOCD
 [submodule "hidapi"]
 	path = hidapi
-	url = git://github.com/signal11/hidapi.git
+	url = https://github.com/signal11/hidapi
 [submodule "libusb"]
 	path = libusb
-	url = git://github.com/libusb/libusb.git
+	url = https://github.com/libusb/libusb
 [submodule "dfu-util"]
 	path = dfu-util
 	url = git://git.code.sf.net/p/dfu-util/dfu-util


### PR DESCRIPTION
https://github.blog/2021-09-01-improving-git-protocol-security-github/ has the details, but without this change, I can't actually pull libusb or hidapi