### PR TITLE
Bump license to `gpl-3.0`

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,4 @@ Some patches were added to target a bunch of problems with [Arduino101](https://
 
 # License
 
-The bash scripts are GPLv2 licensed. Every other software used by these bash scripts has its own license. Consult them to know the terms.
+The bash scripts are GPLv3 licensed. Every other software used by these bash scripts has its own license. Consult them to know the terms.

--- a/compile_linux.sh
+++ b/compile_linux.sh
@@ -1,10 +1,10 @@
 #!/bin/bash -xe
 # Copyright (c) 2016 Arduino LLC
 #
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# as published by the Free Software Foundation; either version 2
-# of the License, or (at your option) any later version.
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -12,8 +12,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 mkdir -p distrib/linux64
 cd libusb

--- a/compile_linux_openocd.sh
+++ b/compile_linux_openocd.sh
@@ -1,10 +1,10 @@
 #!/bin/bash -ex
 # Copyright (c) 2016 Arduino LLC
 #
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# as published by the Free Software Foundation; either version 2
-# of the License, or (at your option) any later version.
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -12,8 +12,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 mkdir -p distrib/arm
 

--- a/compile_mac.sh
+++ b/compile_mac.sh
@@ -1,10 +1,10 @@
 #!/bin/bash -xe
 # Copyright (c) 2016 Arduino LLC
 #
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# as published by the Free Software Foundation; either version 2
-# of the License, or (at your option) any later version.
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -12,8 +12,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 platform=$(o64-clang -v 2>&1 | grep Target | awk {'print $2'} | sed 's/[.].*//g')
 

--- a/compile_win.sh
+++ b/compile_win.sh
@@ -1,10 +1,10 @@
 #!/bin/bash -xe
 # Copyright (c) 2016 Arduino LLC
 #
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# as published by the Free Software Foundation; either version 2
-# of the License, or (at your option) any later version.
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -12,8 +12,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 export CFLAGS="-mno-ms-bitfields"
 mkdir -p distrib/windows

--- a/package.sh
+++ b/package.sh
@@ -1,10 +1,10 @@
 #!/bin/bash -ex
 # Copyright (c) 2014-2016 Arduino LLC
 #
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# as published by the Free Software Foundation; either version 2
-# of the License, or (at your option) any later version.
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -12,8 +12,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 OUTPUT_VERSION=0.11.0-arduino3
 


### PR DESCRIPTION
The license has been bumped to GPL-3.0 to make this project easier to be used as a dependency.